### PR TITLE
Add support for ordered fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ rvm:
   - 2.4
   - 2.5
 script:
-  - bundle exec rubocop
-  - xvfb-run -a bundle exec rspec
+  - xvfb-run -a bundle exec rake ci
 matrix:
   allow_failures:
     - rvm: 2.5

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,38 @@
+begin
+  require 'bundler/setup'
+rescue LoadError
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+end
+
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
+
+require 'fcrepo_wrapper'
+require 'solr_wrapper'
+require 'active_fedora/rake_support'
+
+Bundler::GemHelper.install_tasks
+
+desc 'Run style checker'
+RuboCop::RakeTask.new(:rubocop) do |task|
+  task.fail_on_error = true
+end
+
+desc 'Run specs'
+RSpec::Core::RakeTask.new(:spec)
+
+namespace :tufts do
+  namespace :curation do
+    desc 'Run specs with Fedora & Solr servers'
+    task :spec do
+      with_test_server do
+        Rake::Task['spec'].invoke
+      end
+    end
+  end
+end
+
+desc 'Check style and run specs'
+task ci: ['rubocop', 'tufts:curation:spec']
+
+task default: :ci

--- a/lib/tufts/curation/schema/ordered.rb
+++ b/lib/tufts/curation/schema/ordered.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Tufts
+  module Curation
+    module Schema
+      ##
+      # Schema adding ordered properties to tufts models.
+      #
+      # These properties are used to store the order for their corresponding
+      # (unordered) properties. Don't set the value of these properties
+      # directly. The values will be kept in sync by the setter method for the
+      # corresponding property.
+      #
+      # @example setting an ordered property
+      #    work.description = ['Desc 1', 'Desc 2']
+      #    work.ordered_description # => "['Desc 1', 'Desc 2']"
+      #
+      module Ordered
+        extend ActiveSupport::Concern
+
+        included do
+          property :ordered_creators,
+                   predicate: ::Tufts::Vocab::Tufts.ordered_creators,
+                   multiple: false do |index|
+            index.as :symbol
+          end
+
+          property :ordered_descriptions,
+                   predicate: ::Tufts::Vocab::Tufts.ordered_descriptions,
+                   multiple: false do |index|
+            index.as :symbol
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tufts/curation/spec/shared_examples.rb
+++ b/lib/tufts/curation/spec/shared_examples.rb
@@ -7,6 +7,7 @@ module Tufts
         require 'tufts/curation/spec/shared_examples/a_model_with_a_transcription'
         require 'tufts/curation/spec/shared_examples/a_model_with_admin_schema'
         require 'tufts/curation/spec/shared_examples/a_model_with_descriptive_schema'
+        require 'tufts/curation/spec/shared_examples/a_model_with_ordered_metadata'
         require 'tufts/curation/spec/shared_examples/a_tufts_model'
       end
     end

--- a/lib/tufts/curation/spec/shared_examples/a_model_with_ordered_metadata.rb
+++ b/lib/tufts/curation/spec/shared_examples/a_model_with_ordered_metadata.rb
@@ -1,0 +1,13 @@
+shared_examples 'a model with ordered metadata' do
+  it 'has ordered creators' do
+    expect(work)
+      .to have_editable_property(:ordered_creators)
+      .with_predicate(Tufts::Vocab::Tufts.ordered_creators)
+  end
+
+  it 'has ordered descriptions' do
+    expect(work)
+      .to have_editable_property(:ordered_descriptions)
+      .with_predicate(Tufts::Vocab::Tufts.ordered_descriptions)
+  end
+end

--- a/lib/tufts/curation/spec/shared_examples/a_tufts_model.rb
+++ b/lib/tufts/curation/spec/shared_examples/a_tufts_model.rb
@@ -3,6 +3,7 @@ shared_examples 'a tufts model' do
 
   it_behaves_like 'a model with admin metadata attributes'
   it_behaves_like 'a model with descriptive metadata attributes'
+  it_behaves_like 'a model with ordered metadata'
   it_behaves_like 'a model with hyrax basic metadata'
 
   describe '#title' do
@@ -17,6 +18,74 @@ shared_examples 'a tufts model' do
       expect { work.title = ['moomin', 'moomin 2: the snork strikes back'] }
         .to change { work.valid? }
         .from(true).to(false)
+    end
+  end
+
+  describe 'ordered fields' do
+    describe '#creator' do
+      let(:lancelot) { 'Sir Lancelot du Lac' }
+      let(:gawain) { 'Sir Gawain' }
+      let(:arthur) { 'King Arthur Pendragon' }
+      let(:expected_order) { [arthur, gawain, lancelot] }
+
+      it 'preserves the order' do
+        expect { work.creator = expected_order }
+          .to change { work.creator.to_a }
+          .to eq expected_order
+      end
+
+      it 'updates attributes' do
+        expect { work.creator = expected_order }
+          .to change { work.changed_attributes }
+          .to include(:creator, :ordered_creators)
+      end
+
+      context 'when reloaded' do
+        subject(:work) do
+          described_class.new(title: ['moomin'], creator: expected_order)
+        end
+
+        before { work.save! }
+
+        it 'preserves the order' do
+          expect { work.reload }
+            .not_to change { work.creator.to_a }
+            .from eq expected_order
+        end
+      end
+    end
+
+    describe '#description' do
+      let(:desc_a) { 'AAA' }
+      let(:desc_b) { 'BBB' }
+      let(:desc_c) { 'CCC' }
+      let(:expected_order) { [desc_b, desc_a, desc_c] }
+
+      it 'preserves the order' do
+        expect { work.description = expected_order }
+          .to change { work.description.to_a }
+          .to eq expected_order
+      end
+
+      it 'updates attributes' do
+        expect { work.description = expected_order }
+          .to change { work.changed_attributes }
+          .to include(:description, :ordered_descriptions)
+      end
+
+      context 'when reloaded' do
+        subject(:work) do
+          described_class.new(title: ['moomin'], description: expected_order)
+        end
+
+        before { work.save! }
+
+        it 'preserves the order' do
+          expect { work.reload }
+            .not_to change { work.description.to_a }
+            .from eq expected_order
+        end
+      end
     end
   end
 end

--- a/lib/tufts/curation/tufts_model.rb
+++ b/lib/tufts/curation/tufts_model.rb
@@ -7,6 +7,7 @@ require 'models/concerns/hyrax/basic_metadata'
 require 'tufts/curation/vocab/tufts'
 require 'tufts/curation/schema/administrative'
 require 'tufts/curation/schema/descriptive'
+require 'tufts/curation/schema/ordered'
 require 'tufts/curation/schema/transcription'
 
 module Tufts
@@ -25,10 +26,49 @@ module Tufts
 
       include Tufts::Curation::Schema::Administrative
       include Tufts::Curation::Schema::Descriptive
+      include Tufts::Curation::Schema::Ordered
 
       # This must be included at the end, because it finalizes the metadata
       # schema (by adding accepts_nested_attributes)
       include Hyrax::BasicMetadata
+
+      ##
+      # Overrides setter method to preserve order in a second property.
+      #
+      # @param values [Array<Object] Ordered array of values
+      #
+      # @return [Array<Object>]
+      def creator=(values)
+        super && self.ordered_creators = values.to_json
+      end
+
+      ##
+      # Overrides getter method to return the creators in the correct order.
+      #
+      # @return [Array<Object>]
+      def creator
+        return super if ordered_creators.blank?
+        JSON.parse(ordered_creators)
+      end
+
+      ##
+      # Overrides setter method to preserve order in a second property.
+      #
+      # @param values [Array<Object>] Ordered array of values
+      #
+      # @return [Array<Object>]
+      def description=(values)
+        super && self.ordered_descriptions = values.to_json
+      end
+
+      ##
+      # Overrides getter method to return the descriptions in the correct order.
+      #
+      # @return [Array<Object>]
+      def description
+        return super if ordered_descriptions.blank?
+        JSON.parse(ordered_descriptions)
+      end
     end
   end
 end

--- a/lib/tufts/curation/vocab/tufts.rb
+++ b/lib/tufts/curation/vocab/tufts.rb
@@ -31,6 +31,8 @@ module Tufts
         term :qr_note
         term :creator_department
         term :admin_set_member
+        term :ordered_creators
+        term :ordered_descriptions
       end
     end
   end

--- a/spec/tufts/curation/schema/ordered_spec.rb
+++ b/spec/tufts/curation/schema/ordered_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Tufts::Curation::Schema::Ordered do
+  subject(:work) { model_class.new }
+
+  let(:model_class) do
+    Class.new(ActiveFedora::Base) do
+      include Tufts::Curation::Schema::Ordered
+    end
+  end
+
+  it_behaves_like 'a model with ordered metadata'
+end

--- a/tufts-curation.gemspec
+++ b/tufts-curation.gemspec
@@ -23,15 +23,14 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'active-fedora', '>= 11.5', '<= 12.99'
   gem.add_dependency 'hyrax',         '>= 2.0'
 
-  gem.add_development_dependency 'yard',        '~> 0.9'
-  gem.add_development_dependency 'bixby',       '~> 0.3'
-  gem.add_development_dependency 'hyrax-spec',  '~> 0.2'
-  gem.add_development_dependency 'rspec',       '~> 3.6'
-  gem.add_development_dependency 'guard-rspec', '~> 4.7'
-  gem.add_development_dependency 'coveralls',   '~> 0.8'
+  gem.add_development_dependency 'yard',         '~> 0.9'
+  gem.add_development_dependency 'bixby',        '~> 0.3'
+  gem.add_development_dependency 'hyrax-spec',   '~> 0.2'
+  gem.add_development_dependency 'rspec',        '~> 3.6'
+  gem.add_development_dependency 'coveralls',    '~> 0.8'
+  gem.add_development_dependency 'solr_wrapper', '>= 0.3'
+  gem.add_development_dependency 'fcrepo_wrapper'
 
   gem.files         = `git ls-files`.split("\n")
   gem.test_files    = `git ls-files -- {spec}/*`.split("\n")
-
-  gem.post_install_message = nil
 end


### PR DESCRIPTION
The properties for ordered fields are added by an addition to `Schema`. Setters are altered in `TuftsModel`, since they need to be changed after inclusion of `Hyrax::BasicMetadata`.

Shared examples are added, and included in the various concrete models. These tests are based on those in MIRA (`epigaea`), but refactored somewhat. The old tests can be kept in place there.