### PR TITLE
Add ordered fields to Collections

### DIFF
--- a/lib/tufts/curation/collection.rb
+++ b/lib/tufts/curation/collection.rb
@@ -9,9 +9,49 @@ module Tufts
         index.as :stored_searchable
       end
 
+      include Tufts::Curation::Schema::Ordered
+
       # This must be included at the end, because it finalizes the metadata
       # schema (by adding accepts_nested_attributes)
       include Hyrax::BasicMetadata
+
+      ##
+      # Overrides setter method to preserve order in a second property.
+      #
+      # @param values [Array<Object] Ordered array of values
+      #
+      # @return [Array<Object>]
+      def creator=(values)
+        super && self.ordered_creators = values.to_json
+      end
+
+      ##
+      # Overrides getter method to return the creators in the correct order.
+      #
+      # @return [Array<Object>]
+      def creator
+        return super if ordered_creators.blank?
+        JSON.parse(ordered_creators)
+      end
+
+      ##
+      # Overrides setter method to preserve order in a second property.
+      #
+      # @param values [Array<Object>] Ordered array of values
+      #
+      # @return [Array<Object>]
+      def description=(values)
+        super && self.ordered_descriptions = values.to_json
+      end
+
+      ##
+      # Overrides getter method to return the descriptions in the correct order.
+      #
+      # @return [Array<Object>]
+      def description
+        return super if ordered_descriptions.blank?
+        JSON.parse(ordered_descriptions)
+      end
     end
   end
 end

--- a/lib/tufts/curation/spec/shared_examples/a_tufts_collection.rb
+++ b/lib/tufts/curation/spec/shared_examples/a_tufts_collection.rb
@@ -3,9 +3,81 @@ shared_examples 'a tufts collection' do
 
   it_behaves_like 'a model with hyrax basic metadata'
 
+  it_behaves_like 'a model with ordered metadata' do
+    let(:work) { collection }
+  end
+
   it 'has ead' do
     expect(collection)
       .to have_editable_property(:ead)
       .with_predicate(Tufts::Vocab::Tufts.has_description)
+  end
+
+  describe 'ordered fields' do
+    describe '#creator' do
+      let(:lancelot) { 'Sir Lancelot du Lac' }
+      let(:gawain) { 'Sir Gawain' }
+      let(:arthur) { 'King Arthur Pendragon' }
+      let(:expected_order) { [arthur, gawain, lancelot] }
+
+      it 'preserves the order' do
+        expect { collection.creator = expected_order }
+          .to change { collection.creator.to_a }
+          .to eq expected_order
+      end
+
+      it 'updates attributes' do
+        expect { collection.creator = expected_order }
+          .to change { collection.changed_attributes }
+          .to include(:creator, :ordered_creators)
+      end
+
+      context 'when reloaded' do
+        subject(:collection) do
+          described_class.new(title: ['moomin'], creator: expected_order)
+        end
+
+        before { collection.save! }
+
+        it 'preserves the order' do
+          expect { collection.reload }
+            .not_to change { collection.creator.to_a }
+            .from eq expected_order
+        end
+      end
+    end
+
+    describe '#description' do
+      let(:desc_a) { 'AAA' }
+      let(:desc_b) { 'BBB' }
+      let(:desc_c) { 'CCC' }
+      let(:expected_order) { [desc_b, desc_a, desc_c] }
+
+      it 'preserves the order' do
+        expect { collection.description = expected_order }
+          .to change { collection.description.to_a }
+          .to eq expected_order
+      end
+
+      it 'updates attributes' do
+        expect { collection.description = expected_order }
+          .to change { collection.changed_attributes }
+          .to include(:description, :ordered_descriptions)
+      end
+
+      context 'when reloaded' do
+        subject(:collection) do
+          described_class.new(title: ['moomin'], description: expected_order)
+        end
+
+        before { collection.save! }
+
+        it 'preserves the order' do
+          expect { collection.reload }
+            .not_to change { collection.description.to_a }
+            .from eq expected_order
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Ordered fields in collections was implemented in Epigaea. It's unclear whether this is a requirement--if not, we may need to revert this commit. This work is necessary to pass the tests for `epigaea`.