### PR TITLE
Include Hyrax Work/CollectionBehavior when available

### DIFF
--- a/lib/tufts/curation/schema/ordered_overrides.rb
+++ b/lib/tufts/curation/schema/ordered_overrides.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Tufts
+  module Curation
+    module Schema
+      module OrderedOverrides
+        extend ActiveSupport::Concern
+
+        ##
+        # Overrides setter method to preserve order in a second property.
+        #
+        # @param values [Array<Object] Ordered array of values
+        #
+        # @return [Array<Object>]
+        def creator=(values)
+          super && self.ordered_creators = values.to_json
+        end
+
+        ##
+        # Overrides getter method to return the creators in the correct order.
+        #
+        # @return [Array<Object>]
+        def creator
+          return super if ordered_creators.blank?
+          JSON.parse(ordered_creators)
+        end
+
+        ##
+        # Overrides setter method to preserve order in a second property.
+        #
+        # @param values [Array<Object>] Ordered array of values
+        #
+        # @return [Array<Object>]
+        def description=(values)
+          super && self.ordered_descriptions = values.to_json
+        end
+
+        ##
+        # Overrides getter method to return the descriptions in the correct order.
+        #
+        # @return [Array<Object>]
+        def description
+          return super if ordered_descriptions.blank?
+          JSON.parse(ordered_descriptions)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In a Hyrax application, we want to automatically include the
`Hyrax::WorkBehaivor` and `Hyrax::CollectionBehavior` modules in their
appropriate models. This avoids applications needing to include them in
inherited models manually.

If these behaviors are not defined, then we continue to require and include
`Hyrax::CoreMetadata` and `Hyrax::BasicMetadata` manually.