### PR TITLE
Lock Hyrax support down to 2.0.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ Models and shared curation tools for Tufts University.
 ## Usage
 
 In your `Gemfile` add: `gem 'tufts-curation'`.
+
+## Hyrax Support
+
+These models support Hyrax the 2.0.x release series.

--- a/tufts-curation.gemspec
+++ b/tufts-curation.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'activesupport'
   gem.add_dependency 'active-fedora', '>= 11.5', '<= 12.99'
-  gem.add_dependency 'hyrax',         '>= 2.0'
+  gem.add_dependency 'hyrax',         '~> 2.0.0'
 
   gem.add_development_dependency 'yard',         '~> 0.9'
   gem.add_development_dependency 'bixby',        '~> 0.3'


### PR DESCRIPTION
We are concerned about concurrent applications attempting to share models across
minor versions of Hyrax, so we are locking support to `~> 2.0.0`.

Support for tiny versions within the minor series is left open, though we
recommend taking care when running two different versions of the Hyrax codebase
on applications that may load and save the same objects.