### PR TITLE
Add model setup macro

### DIFF
--- a/lib/tufts/curation.rb
+++ b/lib/tufts/curation.rb
@@ -22,5 +22,45 @@ require 'tufts/curation/voting_record'
 module Tufts
   ##
   # Shared models and curation tools for Tufts Hyrax repositories.
-  module Curation; end
+  module Curation
+    MODELS = { audio:          Tufts::Curation::Audio,
+               ead:            Tufts::Curation::Ead,
+               generic_object: Tufts::Curation::GenericObject,
+               image:          Tufts::Curation::Image,
+               pdf:            Tufts::Curation::Pdf,
+               rcr:            Tufts::Curation::Rcr,
+               tei:            Tufts::Curation::Tei,
+               video:          Tufts::Curation::Video,
+               voting_record:  Tufts::Curation::VotingRecord }.freeze
+
+    ##
+    # Registers curation_concerns with a hyrax application using the passed
+    # in configuration object.
+    #
+    # @example
+    #    # config/initializers/hyrax.rb
+    #    Hyrax.config do |config|
+    #      Tufts::Curation.setup_models!(configuration: config)
+    #      # ..
+    #    end
+    #
+    # @param configuration [Hyrax::Configuration]
+    #
+    # For a block { |model| ... }
+    # @yield each model class defined during setup
+    # @yieldparam model [Class]
+    #
+    # @return [void]
+    def setup_models!(configuration:)
+      MODELS.each do |model_name, parent_class|
+        class_name = model_name.to_s.camelize
+        Object.const_set(class_name, Class.new(parent_class))
+
+        yield class_name.constantize if block_given?
+
+        configuration.register_curation_concern(model_name)
+      end
+    end
+    module_function :setup_models!
+  end
 end

--- a/lib/tufts/curation/tufts_model.rb
+++ b/lib/tufts/curation/tufts_model.rb
@@ -24,6 +24,7 @@ module Tufts
       # `Hyrax::CoreMetadata` and `Hyrax::BasicMetadata` in place.
       def self.inherited(subclass)
         subclass.include 'Hyrax::WorkBehavior'.constantize
+        subclass.indexer = Tufts::Curation::Indexer
       rescue NameError => e
         # Don't bother reporting failure to load for classes defined in this
         # namespace, which are assumed to be abstract.

--- a/spec/tufts/curation_spec.rb
+++ b/spec/tufts/curation_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'set'
+
+describe Tufts::Curation do
+  describe '.setup_models!' do
+    let(:configuration) { configuration_class.new }
+
+    let(:configuration_class) do
+      # rubocop:disable RSpec/InstanceVariable
+      Class.new do
+        attr_reader :registered_concerns
+
+        def register_curation_concern(*curation_concern_types)
+          @registered_concerns ||= Set.new
+          @registered_concerns.merge(curation_concern_types)
+        end
+
+        def curation_concerns
+          @registered_concerns.map { |model_name| model_name.to_s.camelize.constantize }
+        end
+      end
+      # rubocop:enable RSpec/InstanceVariable
+    end
+
+    let(:expected_concerns) { described_class::MODELS.keys }
+
+    it 'registers concerns for the objects' do
+      expect { described_class.setup_models!(configuration: configuration) }
+        .to change { configuration.registered_concerns }
+        .to contain_exactly(*expected_concerns)
+    end
+
+    it 'yields each concern type' do
+      expect { |b| described_class.setup_models!(configuration: configuration, &b) }
+        .to yield_control.exactly(expected_concerns.count).times
+    end
+  end
+end


### PR DESCRIPTION
Adds a method intended for use in an initializer to define application layer
models. Using this with:

    Hyrax.config do |config|
      Tufts::Curation.setup_models!(configuration: config)
    end

Defines local model classes for each `Tufts::Curation` model, and registers with
the given config object (which should be a `Hyrax::Configuration`).

Indexers are defined automatically to use the default `Tufts::Curation::Indexer`
on each defined `TuftsModel` subclass.