### PR TITLE
Setup FileSet and Collection

### DIFF
--- a/lib/tufts/curation.rb
+++ b/lib/tufts/curation.rb
@@ -8,6 +8,7 @@ require 'rdf/vocab'
 require 'tufts/curation/indexer'
 require 'tufts/curation/tufts_model'
 require 'tufts/curation/collection'
+require 'tufts/curation/file_set'
 
 require 'tufts/curation/audio'
 require 'tufts/curation/ead'
@@ -60,6 +61,9 @@ module Tufts
 
         configuration.register_curation_concern(model_name)
       end
+
+      Object.const_set('FileSet', Class.new(Tufts::Curation::FileSet))
+      Object.const_set('Collection', Class.new(Tufts::Curation::Collection))
     end
     module_function :setup_models!
   end

--- a/lib/tufts/curation/collection.rb
+++ b/lib/tufts/curation/collection.rb
@@ -11,6 +11,7 @@ module Tufts
       # `Hyrax::CoreMetadata` and `Hyrax::BasicMetadata` in place.
       def self.inherited(subclass)
         subclass.include 'Hyrax::CollectionBehavior'.constantize
+        subclass.indexer = Hyrax::CollectionWithBasicMetadataIndexer
       rescue NameError => e
         warn 'Hyrax::CollectionBehavior is unavailable; skipping inclusion ' \
              "in #{subclass}.\n#{e}"

--- a/lib/tufts/curation/file_set.rb
+++ b/lib/tufts/curation/file_set.rb
@@ -1,0 +1,17 @@
+module Tufts
+  module Curation
+    ##
+    # A base class for Tufts FileSets
+    class FileSet < ActiveFedora::Base
+      ##
+      # Use `Hyrax::FileSet` in subclasses if it is available. Hyrax
+      # applications will have this loaded.
+      def self.inherited(subclass)
+        subclass.include 'Hyrax::FileSetBehavior'.constantize
+      rescue NameError => e
+        warn 'Hyrax::FileSetBehavior is unavailable; skipping inclusion ' \
+             "in #{subclass}.\n#{e}"
+      end
+    end
+  end
+end

--- a/lib/tufts/curation/spec/shared_examples.rb
+++ b/lib/tufts/curation/spec/shared_examples.rb
@@ -9,6 +9,7 @@ module Tufts
         require 'tufts/curation/spec/shared_examples/a_model_with_descriptive_schema'
         require 'tufts/curation/spec/shared_examples/a_model_with_ordered_metadata'
         require 'tufts/curation/spec/shared_examples/a_tufts_collection'
+        require 'tufts/curation/spec/shared_examples/a_tufts_file_set'
         require 'tufts/curation/spec/shared_examples/a_tufts_model'
       end
     end

--- a/lib/tufts/curation/spec/shared_examples/a_tufts_file_set.rb
+++ b/lib/tufts/curation/spec/shared_examples/a_tufts_file_set.rb
@@ -1,0 +1,7 @@
+shared_examples 'a tufts file set' do
+  subject(:file_set) { described_class.new }
+
+  it 'is a saveable model' do
+    expect { file_set.save }.not_to raise_error
+  end
+end

--- a/spec/tufts/curation/file_set_spec.rb
+++ b/spec/tufts/curation/file_set_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Tufts::Curation::FileSet do
+  it_behaves_like 'a tufts file set'
+end

--- a/spec/tufts/curation_spec.rb
+++ b/spec/tufts/curation_spec.rb
@@ -32,6 +32,16 @@ describe Tufts::Curation do
         .to contain_exactly(*expected_concerns)
     end
 
+    it 'defines Collection' do
+      described_class.setup_models!(configuration: configuration)
+      expect(defined?(Collection)).to eq 'constant'
+    end
+
+    it 'defines FileSet' do
+      described_class.setup_models!(configuration: configuration)
+      expect(defined?(FileSet)).to eq 'constant'
+    end
+
     it 'yields each concern type' do
       expect { |b| described_class.setup_models!(configuration: configuration, &b) }
         .to yield_control.exactly(expected_concerns.count).times


### PR DESCRIPTION
Adds support for `FileSet`, allowing applications to inherit `Tufts::Curation::FileSet`.

Extends `Tufts::Curation.setup_models!` to define top-level `Collection` and
`FileSet` classes. This avoids the need to define and inherit manually on
application setup.