### PR TITLE
Set `Hyrax.config.admin_set_predicate` on `model_setup!`

### DIFF
--- a/lib/tufts/curation.rb
+++ b/lib/tufts/curation.rb
@@ -53,6 +53,8 @@ module Tufts
     #
     # @return [void]
     def setup_models!(configuration:)
+      configuration.admin_set_predicate = Tufts::Vocab::Tufts.admin_set_member
+
       MODELS.each do |model_name, parent_class|
         class_name = model_name.to_s.camelize
         Object.const_set(class_name, Class.new(parent_class))

--- a/spec/tufts/curation_spec.rb
+++ b/spec/tufts/curation_spec.rb
@@ -10,6 +10,7 @@ describe Tufts::Curation do
     let(:configuration_class) do
       # rubocop:disable RSpec/InstanceVariable
       Class.new do
+        attr_accessor :admin_set_predicate
         attr_reader :registered_concerns
 
         def register_curation_concern(*curation_concern_types)
@@ -30,6 +31,12 @@ describe Tufts::Curation do
       expect { described_class.setup_models!(configuration: configuration) }
         .to change { configuration.registered_concerns }
         .to contain_exactly(*expected_concerns)
+    end
+
+    it 'defines configuration#admin_set_predicate' do
+      expect { described_class.setup_models!(configuration: configuration) }
+        .to change { configuration.admin_set_predicate }
+        .to Tufts::Vocab::Tufts.admin_set_member
     end
 
     it 'defines Collection' do


### PR DESCRIPTION
All client apps should use the same predicate for the `AdminSet` relation. We set that automatically as part of the model setup.